### PR TITLE
baseUrl ➡️ originalUrl

### DIFF
--- a/index.js
+++ b/index.js
@@ -191,7 +191,7 @@ function middleware (resolver, opts={}) {
         return;
       }
 
-      const urlMatches = req.baseUrl.match(/(?:@([0-9]+)x)?\.(png|json)$/);
+      const urlMatches = req.originalUrl.match(/(?:@([0-9]+)x)?\.(png|json)$/);
       if (!urlMatches) {
         throw new Error("Expected URL to have suffix of format /(@[0.9]+x)?\.(png|json)/")
       }


### PR DESCRIPTION
In some environments `baseUrl` seems to be incorrect. This required us to set `req.baseUrl` which is hacky. 

```js
req.baseUrl = req.url
```

`req.url` is also set to something odd when being used by standard express middleware `app.use("/", middleware)`. Since we just match the trailing parameters `/(?:@([0-9]+)x)?\.(png|json)$/` anyway `req.originalUrl` seems like the correct choice.