### PR TITLE
Limit SVG density to 2400

### DIFF
--- a/index.js
+++ b/index.js
@@ -112,6 +112,7 @@ async function fetchImage (imgDef) {
 
       const image = sharp(inBuffer);
       const metadata = await image.metadata();
+      let density = metadata.density;
       if (imgDef.width && metadata.width && imgDef.width > metadata.width) {
         // We must limit to 2400
         // <https://github.com/lovell/sharp/issues/1421#issuecomment-514446234>

--- a/index.js
+++ b/index.js
@@ -112,11 +112,13 @@ async function fetchImage (imgDef) {
 
       const image = sharp(inBuffer);
       const metadata = await image.metadata();
-      const {width, height} = metadata;
-      let {density} = metadata;
-      const ratio = (imgDef.width / width);
-      if (ratio > 1) {
-        density = density * ratio;
+      if (imgDef.width && metadata.width && imgDef.width > metadata.width) {
+        // We must limit to 2400
+        // <https://github.com/lovell/sharp/issues/1421#issuecomment-514446234>
+        density = Math.min(
+          2400,
+          (72 * imgDef.width) / metadata.width
+        );
       }
 
       const buffer = await sharp(inBuffer, {density})


### PR DESCRIPTION
Related to issue #2. This doesn't really _fix_ the issue because if the ratio gets to high it'll end up blurring as it increases in size. However that's probably better than causing an error right now.