### PR TITLE
Error for URLs without '@{N}x.{ext}'

### DIFF
--- a/index.js
+++ b/index.js
@@ -199,7 +199,7 @@ function middleware (resolver, opts={}) {
         return;
       }
 
-      const urlMatches = req.originalUrl.match(/(?:@([0-9]+)x)?\.(png|json)$/);
+      const urlMatches = req.originalUrl.match(/(?:@([0-9]+)x)\.(png|json)$/);
       if (!urlMatches) {
         next(new Error("Expected URL to have suffix of format /(@[0.9]+x)?\.(png|json)/"))
         return;

--- a/test/middleware.js
+++ b/test/middleware.js
@@ -275,14 +275,22 @@ describe("middleware", () => {
       return [];
     })
 
-    const res = await fetch(testServer.url("sprite_foobar"));
-    assert.equal(res.status, 500);
+    const requestUrls = [
+      testServer.url("sprite_foobar"),
+      testServer.url("sprite.json"),
+      testServer.url("sprite.png"),
+    ];
 
-    // The format will be from your own error handler.
-    // See `./test/helper.js` appServer function
-    assert.deepStrictEqual(await res.json(), {
-      type: "error",
-      data: "Error: Expected URL to have suffix of format /(@[0.9]+x)?.(png|json)/"
-    });
+    for (let url of requestUrls) {
+      const response = await fetch(url);
+      assert.equal(response.status, 500);
+
+      // The format will be from your own error handler.
+      // See `./test/helper.js` appServer function
+      assert.deepStrictEqual(await response.json(), {
+        type: "error",
+        data: "Error: Expected URL to have suffix of format /(@[0.9]+x)?.(png|json)/"
+      });
+    }
   });
 });


### PR DESCRIPTION
A fix to _500_ if a URL without a `@{N}x.{ext}` extension is passed, for example the following now fail

```
/sprite.json
/sprite.png
```

Whereas before they would attempt to complete, which would cause `pixelRatio` to be `null` causing all sorts of odd errors in the code. 