### PR TITLE
Round width/height to integers

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,15 @@ function json (imgs, opts={}) {
   };
   const {pixelRatio} = opts;
   const sprite = new ShelfPack(1, 1, { autoResize: true });
-  const results = sprite.pack(imgs, { inPlace: true });
+
+  const clampedSizedImages = imgs.map(img => {
+    return {
+      ...img,
+      width: Math.round(img.width),
+      height: Math.round(img.height),
+    }
+  })
+  const results = sprite.pack(clampedSizedImages, { inPlace: true });
 
   const out = {};
   results.forEach(item => {
@@ -40,7 +48,7 @@ function json (imgs, opts={}) {
   return {
     width: sprite.w*pixelRatio,
     height: sprite.h*pixelRatio,
-    images: imgs,
+    images: clampedSizedImages,
     boxes: out,
     pixelRatio,
   };

--- a/test/json.js
+++ b/test/json.js
@@ -95,5 +95,52 @@ describe("json", () => {
       pixelRatio: 2
     });
   });
+
+  it("rounded dimensions", async () => {
+    const imgs = [
+      {
+        "id": "foo",
+        "url": "http://example.com/foo.png",
+        "width": 30.4,
+        "height": 80.4,
+      },
+      {
+        "id": "bar",
+        "url": "http://example.com/bar.png",
+        "width": 49.9,
+        "height": 39.9,
+      },
+    ];
+
+    const result = spriter.json(imgs);
+
+    assert.deepStrictEqual(result, {
+      width: 50,
+      height: 120,
+      images: [
+        {
+          id: 'foo',
+          url: 'http://example.com/foo.png',
+          width: 30,
+          height: 80,
+          x: 0,
+          y: 0
+        },
+        {
+          id: 'bar',
+          url: 'http://example.com/bar.png',
+          width: 50,
+          height: 40,
+          x: 0,
+          y: 80
+        }
+      ],
+      boxes: {
+        foo: { pixelRatio: 1, width: 30, height: 80, x: 0, y: 0 },
+        bar: { pixelRatio: 1, width: 50, height: 40, x: 0, y: 80 }
+      },
+      pixelRatio: 1
+    });
+  });
 });
 

--- a/test/png.js
+++ b/test/png.js
@@ -103,6 +103,31 @@ describe("png", () => {
       buffer.equals(resultBuffer)
     );
   });
+
+  it("rounded dimensions", async () => {
+    const imgs = [
+      {
+        "id": "foo",
+        "url": `http://localhost:${port}/red.svg`,
+        "width": 30.4,
+        "height": 80.4,
+      },
+      {
+        "id": "bar",
+        "url": `http://localhost:${port}/blue.png`,
+        "width": 49.9,
+        "height": 39.9,
+      },
+    ];
+
+    const json = spriter.json(imgs);
+    const {buffer, missingImages} = await spriter.png(json);
+    assert.deepStrictEqual(missingImages, []);
+    const resultBuffer = await fs.promises.readFile(__dirname+"/results/no_pixel_ratio.png");
+    assert(
+      buffer.equals(resultBuffer)
+    );
+  });
 });
 
 


### PR DESCRIPTION
Round input width/height to integers because it's expected  by users.